### PR TITLE
Fix autotools bootstrapping

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-SUBDIRS = lib src man tests
-ACLOCAL_AMFLAGS = -Im4
+SUBDIRS = src man tests
 EXTRA_DIST = build-aux/autogen.sh build-aux/make-scantab.pl ChangeLog.old \
     build-aux/pretty-usage.pl build-aux/style-check.pl build-aux/make-crctab.pl

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,6 @@ AC_INIT([lbzip2], [2.3])
 
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
-AC_CONFIG_HEADERS([lib/config.h])
 
 AM_INIT_AUTOMAKE([1.11 color-tests])
 AM_SILENT_RULES([yes])
@@ -111,8 +110,7 @@ AC_ARG_ENABLE([warnings],
 
 gl_INIT
 
-AC_CONFIG_FILES([Makefile src/Makefile lib/Makefile man/Makefile
-    tests/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile man/Makefile tests/Makefile])
 AC_OUTPUT
 
 


### PR DESCRIPTION
The lib and m4 subdirs are deleted so they need to be removed from
the buildsystem.

Signed-off-by: Justin Lecher jlec@gentoo.org
