### PR TITLE
Align zero-length array to avoid unaligned accesses

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -62,7 +62,7 @@ struct decoder_state {
   uint8_t rle_char;             /* current character */
   uint8_t rle_prev;             /* prevoius character */
 
-  uint32_t tt[0];
+  uint32_t tt[0] __attribute__((aligned (8)));
 };
 
 


### PR DESCRIPTION
When make_tree() creates the left-justified base table (uint64_t *B)
it does so with 64-bit stores:

    B[k] = sofar;

But B points to memory in the zero-length array "uint32_t tt[0]" at the
end of struct decoder_state. Since tt's type is uint32_t, it is only
aligned to a four byte boundary, and so the 64-bit store in make_tree()
causes an unaligned trap on strict platforms like sparc.