### PR TITLE
Define the GNULIB_XALLOC_DIE macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,9 @@ AC_PROG_LN_S
 AC_PROG_RANLIB
 AC_PROG_CC_C89
 
+AC_DEFINE(GNULIB_XALLOC_DIE, 1,
+  [This package is providing its own definition of the xalloc_die function.])
+
 gl_ASSERT_NO_GNULIB_TESTS
 gl_ASSERT_NO_GNULIB_POSIXCHECK
 gl_EARLY


### PR DESCRIPTION
This avoids an implicit function declaration when building gnulib's xmalloc.c, addressing a build failure with future compiler version.

Solution proposed by Bruno Haible here: [Re: xmalloc calling undeclared xalloc_die function](https://lists.gnu.org/archive/html/bug-gnulib/2022-12/msg00038.html)

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
